### PR TITLE
Don't use $ in temp filenames

### DIFF
--- a/lib/runners/console.js
+++ b/lib/runners/console.js
@@ -17,7 +17,7 @@ function ConsoleRunner(args) {
 }
 ConsoleRunner.prototype = Object.create(Runner.prototype);
 ConsoleRunner.prototype.run = function(test, cb) {
-    var file = '$tmp' + counter++ + '.js';
+    var file = '__tmp' + counter++ + '.js';
 
     var command = this.command + ' ' + file;
 


### PR DESCRIPTION
It breaks things on *nix

Credit for finding this goes to @kentaromiura. I just did a quick untested ghetto pull request using the GitHub UI.
