### PR TITLE
use test/harness as helper dir if present

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,9 +3,14 @@
 
 var fs = require('fs');
 var parseFile = require('test262-parser').parseFile;
+var helperDir = __dirname + '/helpers/'; 
 
-fs.readdirSync(__dirname + '/helpers')
+if (fs.existsSync('test/harness')) {
+    helperDir = 'test/harness/';
+}
+
+fs.readdirSync(helperDir)
     .forEach(function(file) {
         exports[file] =
-            parseFile({contents: fs.readFileSync(__dirname + '/helpers/' + file, 'utf-8'), file: file});
+            parseFile({contents: fs.readFileSync(helperDir + file, 'utf-8'), file: file});
     });


### PR DESCRIPTION
I think this got lost in my earlier (noisy) PR, but here is the code that uses test/harness as the helper dir.  Convenient if running in the test262 directory.
