### PR TITLE
Test Exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ t262.useConfig({
 
 the command `test262-harness -c t262.js ../test262/test/suite/**/*.js` will run all of test262 in jsshell.
 
+You may also pass in an array of test globs you wish to exclude from running under 'exclude' property in config. For example, this will exclude all tests in chapter 8 from running:
+
+```javascript
+t262.useConfig({
+    exclude: ["../test262/test/suite/ch08/**/*.js"]
+})
+```
+
 ## Runners
 This harness is capable of running tests out of the box on a number of different hosts. Today these include Node, jsshell, and generic console hosts. You can also subclass any of these runners to provide custom behavior, for example to support transpilation tools. See the Runner API below for more details on how to do this.
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "stream-bifurcate": "^1.0.0",
     "tap": "~0.4.11",
     "test262-parser": "^1.0.2",
-    "through": "~2.3.4"
+    "through": "~2.3.4",
+    "minimatch": "~2.0.1"
   },
   "author": "Brian Terlson",
   "license": "BSD",

--- a/test/excludeConfig.js
+++ b/test/excludeConfig.js
@@ -1,0 +1,6 @@
+var t262 = require('../');
+t262.useConfig({
+	// test exclusion of multiple globs
+	// exclude tests start with a or b
+    exclude: ["test/collateral/a*.js", "test/collateral/b*.js"]
+})

--- a/test/expected.js
+++ b/test/expected.js
@@ -20,4 +20,10 @@ all.noTestStrict = all.filter(function(t) {
     return seen[t.file] = true;
 })
 
+// non-strict test results excluding tests starting with a or b
+all.excludeAB = all.noTestStrict.filter(function(t) {
+    return (t.file.indexOf('test/collateral/a') *
+        t.file.indexOf('test/collateral/b') != 0)
+})
+
 module.exports = all;

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,9 @@ runners.forEach(function(runner) {
     });
 });
 
+// test exclusion
+utils.testResultsCorrect('-c test/excludeConfig.js', expected.excludeAB);
+
 // batch mode supported by console runner
 utils.testResultsCorrect('-r console -e node -b 5 -c test/nodeConfig.js', expected.noTestStrict);
 utils.testResultsCorrect('-r console -e node -b 5 --testStrict -c test/nodeConfig.js', expected);


### PR DESCRIPTION
Enable test exclusion. Put an array of globs in exclude property in config file to exclude tests from running. Tests added.

Example:
t262.useConfig({
    exclude: ["../test262/test/suite/ch08/**/*.js"]
}) 