### PR TITLE
Set 'displayErrors: false' when creating new context to support node>0.10

### DIFF
--- a/lib/runners/node-ip.js
+++ b/lib/runners/node-ip.js
@@ -27,7 +27,7 @@ NodeRunner.prototype.execute = function(test, cb) {
         process: process
     }
     try {
-        vm.runInNewContext(contents, context);
+        vm.runInNewContext(contents, context, {displayErrors: false});
     } catch(e) {
         error = e;
     }

--- a/lib/runners/nodehost.js
+++ b/lib/runners/nodehost.js
@@ -30,7 +30,7 @@ process.stdin.on('data', function(test) {
     }
 
     try {
-        vm.runInNewContext(test, context);
+        vm.runInNewContext(test, context, {displayErrors: false});
     } catch(e) {
         context.$DONE(e);
     }

--- a/test/nodeConfig.js
+++ b/test/nodeConfig.js
@@ -2,6 +2,6 @@ var t262 = require('../');
 t262.useConfig({
     batchConfig: {
         createEnv: 'require("vm").createContext()',
-        runBatched: 'env.process = process;env.console=console;require("vm").runInContext(test, env);'
+        runBatched: 'env.process = process;env.console=console;require("vm").runInContext(test, env, {displayErrors: false});'
     }
 })


### PR DESCRIPTION
To be able to run `npm test` on node > 0.10 and io.js the `displayErrors` option needs to be set.

Tested on: node 0.10.35, node 0.12 branch, io.js

http://strongloop.com/strongblog/node-js-v0-12-apis-breaking/#vm