### PR TITLE
add failing test that should trigger timeout

### DIFF
--- a/test/collateral/timeout.js
+++ b/test/collateral/timeout.js
@@ -3,7 +3,8 @@ description: infinite loop test
 negative: /imeout/
 ---*/
 
-for(;;) {}
+if (0) {
+  // causes test to be detected as async
+  $DONE();
+}
 
-// should cause a timeout
-$DONE();

--- a/test/collateral/timeout.js
+++ b/test/collateral/timeout.js
@@ -1,0 +1,9 @@
+/*---
+description: infinite loop test
+negative: /imeout/
+---*/
+
+for(;;) {}
+
+// should cause a timeout
+$DONE();


### PR DESCRIPTION
Here's a test that should trigger the timeout handling of the various test runners.  Currently this test causes the test runner to hang, so this PR is incomplete.

I'm happy to take suggestions on how to fix this, or it can be Brian's project since @anba fixed #30.
