### PR TITLE
Avoid errors in inter-process test transmission

### DIFF
--- a/lib/runners/node.js
+++ b/lib/runners/node.js
@@ -43,6 +43,7 @@ NodeRunner.prototype.execute = function(test, cb) {
     this._test = test;
     this._testDone = cb;
     this._instance.stdin.write(test.contents);
+    this._instance.stdin.write('<< test262-harness end of test >>');
 }
 
 NodeRunner.prototype.end = function() {

--- a/lib/runners/nodehost.js
+++ b/lib/runners/nodehost.js
@@ -8,8 +8,7 @@ Test262Error.prototype.toString = function () {
     return "Test262Error: " + this.message;
 };
 
-process.stdin.resume();
-process.stdin.on('data', function(test) {
+function runTest(test) {
     var result = { log: [] }
     var context = {
         $ERROR: function(err) {
@@ -43,4 +42,56 @@ process.stdin.on('data', function(test) {
     } catch(e) {
         context.$DONE(e);
     }
+}
+
+/**
+ * Collect data emitted by a stream into "whole" strings (as defined according
+ * to the presence of some delimiter), and invoke the provided callback with
+ * each.
+ *
+ * @param {ReadableStream} stream
+ * @param {string} delimter
+ * @param {function} onComplete - invoked asynchronously with each "whole"
+ *                                value as the second argument; in the event of
+ *                                and error, invoked with the error as the
+ *                                first argument
+ */
+function collectChunks(stream, delimiter, onComplete) {
+    var buffer = '';
+    stream.on('data', function(chunk) {
+        var parts;
+        buffer += chunk.toString();
+
+        parts = buffer.split(delimiter);
+
+        buffer = parts.pop();
+
+        // If `parts` has any elements, they are fully-formed values
+        parts.forEach(function(whole) {
+            setTimeout(onComplete.bind(null, null, whole), 0);
+        });
+    });
+
+    stream.on('error', function(error) {
+        onComplete(error);
+    });
+}
+
+/**
+ * A stream is used here because the system architecture dictates a process
+ * boundary, and standard in/out is the most natural way to conduct
+ * inter-process communication.
+ *
+ * Streams are a sub-optimal transport mechanism for test files because the
+ * data cannot be meaningfully decomposed into smaller pieces. The runtime may
+ * choose to segment large payloads into any arbitrary number of chunks, so no
+ * guarantees can be made about the completeness of a given chunk emitted in a
+ * `data` event.
+ *
+ * Use a simple delimiter-based protocol to ensure that the host only attempts
+ * to execute fully-formed tests.
+ */
+process.stdin.resume();
+collectChunks(process.stdin, '<< test262-harness end of test >>', function(err, test) {
+    runTest(test);
 });


### PR DESCRIPTION
Ensure that only fully-formed tests are executed by the Node.js "host"
process (even in cases where the runtime segments data transmitted over
standard in).

@bterlson Beyond preventing transmission errors (which may be uncommon), introducing a formal protocol like this will help with communicating completeness for `raw` tests (which cannot include the `$DONE` callback).