### PR TITLE
Re-use Test262Error

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -7,7 +7,7 @@ var fs = require('fs');
 var path = require('path');
 var parseFile = require('test262-parser').parseFile;
 
-var autoIncludes = ['assert.js'];
+var autoIncludes = ['Test262Error.js', 'assert.js'];
 
 function Runner(opts) {
     this.opts = opts

--- a/lib/runners/console.js
+++ b/lib/runners/console.js
@@ -8,18 +8,6 @@ var fs = require('fs');
 var cp = require('child_process');
 var counter = 0;
 
-var test262Error = function() {
-    function Test262Error(message) {
-        if (message) this.message = message;
-    }
-
-    Test262Error.prototype.name = "Test262Error";
-    
-    Test262Error.prototype.toString = function () {
-        return "Test262Error: " + this.message;
-    };
-}.toString().slice(14, -1);
-
 var doneFn = function $DONE(err) {
     if(err) $ERROR(err);
     $LOG('test262/done');
@@ -52,7 +40,6 @@ function ConsoleRunner(args) {
     if(args.batch) {
         // Done comes from the parent context
         this.deps = [
-            test262Error,
             errorFn,
             this.logFn
         ]
@@ -64,7 +51,6 @@ function ConsoleRunner(args) {
         }
     } else {
         this.deps = [
-            test262Error,
             doneFn,
             errorFn,
             this.logFn

--- a/lib/runners/node-ip.js
+++ b/lib/runners/node-ip.js
@@ -6,14 +6,6 @@ module.exports = NodeRunner;
 var vm = require('vm');
 var Runner = require('../runner');
 
-function Test262Error(message) {
-    if (message) this.message = message;
-}
-
-Test262Error.prototype.toString = function () {
-    return this.message;
-};
-
 function NodeRunner() { Runner.apply(this, arguments); }
 NodeRunner.prototype = Object.create(Runner.prototype);
 NodeRunner.prototype.execute = function(test, cb) {
@@ -21,11 +13,10 @@ NodeRunner.prototype.execute = function(test, cb) {
     var error;
     var result = {log: []};
     
-    var context = {
+    var context = vm.createContext({
         $ERROR: function(err) {
-            if(typeof err === "object" && err !== null && "name" in err)
-                throw err;
-            else throw new Test262Error(err);
+            var Test262Error = vm.runInContext('Test262Error', context);
+            throw new Test262Error(err);
         },
         $DONE: function(err) {
             error = err;
@@ -34,12 +25,11 @@ NodeRunner.prototype.execute = function(test, cb) {
         $LOG: function(log) {
             result.log.push(log);
         },
-        process: process,
-        Test262Error: Test262Error
-    }
+        process: process
+    });
 
     try {
-        vm.runInNewContext(contents, context, {displayErrors: false});
+        vm.runInContext(contents, context, {displayErrors: false});
     } catch(e) {
         error = e;
     }

--- a/lib/runners/nodehost.js
+++ b/lib/runners/nodehost.js
@@ -1,21 +1,12 @@
 var vm = require('vm');
 
-function Test262Error(message) {
-    if (message) this.message = message;
-}
-
-Test262Error.prototype.toString = function () {
-    return "Test262Error: " + this.message;
-};
-
 process.stdin.resume();
 process.stdin.on('data', function(test) {
     var result = { log: [] }
-    var context = {
-        $ERROR: function(err) {
-            if(typeof err === "object" && err !== null && "name" in err)
-                throw err;
-            else throw new Test262Error(err);
+    var context = vm.createContext({
+        $ERROR: function(msg) {
+            var Test262Error = vm.runInContext('Test262Error', context);
+            throw new Test262Error(msg);
         },
         $DONE: function(error) {
             if(error) {
@@ -34,12 +25,11 @@ process.stdin.on('data', function(test) {
         $LOG: function(log) {
             console.log(log);
         },
-        process: process,
-        Test262Error: Test262Error
-    }
+        process: process
+    });
 
     try {
-        vm.runInNewContext(test, context, {displayErrors: false});
+        vm.runInContext(test, context, {displayErrors: false});
     } catch(e) {
         context.$DONE(e);
     }

--- a/test/test262alike/badHarness/Test262Error.js
+++ b/test/test262alike/badHarness/Test262Error.js
@@ -1,0 +1,1 @@
+// dummy assert file

--- a/test/test262alike/harness/Test262Error.js
+++ b/test/test262alike/harness/Test262Error.js
@@ -1,0 +1,1 @@
+// dummy assert file


### PR DESCRIPTION
Reduce coupling between runner implementations and Test262 itself by
automatically injecting Test262's definition of `Test262Error`.