### PR TITLE
Fix the error with redirecting stdout to a file on Windows

### DIFF
--- a/lib/simpleReporter.js
+++ b/lib/simpleReporter.js
@@ -34,8 +34,10 @@ function actualString(test) {
 }
 
 module.exports = through(function(data) {
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
+    if (process.stdout.clearLine && process.stdout.cursorTo) {
+        process.stdout.clearLine();
+        process.stdout.cursorTo(0);
+    }
 
     if(data.pass) {
         state.pass++;
@@ -49,8 +51,10 @@ module.exports = through(function(data) {
                              "     Got: " + actualString(data) + "\n\n");
     }
 }, function() {
-    process.stdout.clearLine();
-    process.stdout.cursorTo(0);
+    if (process.stdout.clearLine && process.stdout.cursorTo) {
+        process.stdout.clearLine();
+        process.stdout.cursorTo(0);
+    }
     console.log("Ran " + (state.pass + state.fail) + " tests")
     console.log(state.pass + " passed")
     console.log(state.fail + " failed")


### PR DESCRIPTION
Without this fix, a command like `test262-harness > test.log` leads to this (Node v4.1.0, Windows 7 x64):

```
d:\project\node_modules\test262-harness\lib\simpleReporter.js:38
    process.stdout.clearLine();
                   ^

TypeError: process.stdout.clearLine is not a function
    at Stream.<anonymous> (d:\project\node_modules\test262-harness\lib\simpleReporter.js:38:20)
    at Stream.stream.write (d:\project\node_modules\test262-harness\node_modules\through\index.js:26:11)
    at d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:882:23
    at Stream.s._send (d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:1139:9)
    at Stream.write (d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:1220:18)
    at Stream._send (d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:657:32)
    at Stream.write (d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:1220:18)
    at Stream._generator_push (d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:489:18)
    at d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:3476:21
    at d:\project\node_modules\test262-harness\node_modules\highland\lib\index.js:1173:9
```