### PR TITLE
Add a baseline reporter

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -23,6 +23,7 @@ var args = require('minimist')(process.argv.slice(2), {
 var parser = require('test262-parser');
 var tapify = require('../lib/tapify');
 var simpleReporter = require('../lib/simpleReporter.js');
+var baselineReporter = require('../lib/baselineReporter.js');
 var _ = require('highland');
 var glob = require('glob');
 var fs = require('fs');
@@ -97,6 +98,13 @@ cli.launch({
         results.pipe(jss).pipe(process.stdout);
     } else if(t262.config.reporter === 'tap') {
         results.pipe(tapify).pipe(process.stdout);
+    } else if(t262.config.reporter === 'baseline') {
+        results.pipe(baselineReporter(t262.config.test262Dir || process.cwd()));
+
+        results.on('end', function() {
+            // show time on stderr to exclude it from baseline output
+            console.error("Took " + ((Date.now() - start) / 1000) + " seconds");
+        });
     } else if(t262.config.reporter === 'simple') {
         results.pipe(simpleReporter);
 

--- a/lib/baselineReporter.js
+++ b/lib/baselineReporter.js
@@ -1,0 +1,43 @@
+var through = require('through');
+var path = require('path');
+var tty = require('tty');
+var EOL = require('os').EOL;
+
+var state = {
+    pass: 0,
+    fail: 0,
+}
+
+function canonicalizePath(p) {
+    if(path.sep === '\\') {
+        // canonicalize on forward slash seperator
+        p = p.replace(/\\/g, '/');
+    }
+    return p;
+}
+
+module.exports = function(basePath) {
+    basePath = canonicalizePath(basePath);
+
+    return through(function(data) {
+        if(data.pass) {
+            state.pass++;
+            process.stdout.write("PASS " + canonicalizePath(path.relative(basePath, data.file)) + EOL);
+        } else {
+            state.fail++;
+            process.stdout.write("FAIL " + canonicalizePath(path.relative(basePath, data.file)) + EOL);
+        }
+    }, function() {
+        // output stats to both baseline on stdout and console on stderr
+        // but do not output to stdout if it was not redirected to a file
+        if(!tty.isatty(process.stdout.fd)) {
+            process.stdout.write("Ran " + (state.pass + state.fail) + " tests" + EOL)
+            process.stdout.write(state.pass + " passed" + EOL)
+            process.stdout.write(state.fail + " failed" + EOL)
+        }
+
+        process.stderr.write("Ran " + (state.pass + state.fail) + " tests" + EOL)
+        process.stderr.write(state.pass + " passed" + EOL)
+        process.stderr.write(state.fail + " failed" + EOL)
+    });
+}


### PR DESCRIPTION
Prints out only PASS/FAIL and the relative test file path for each test
followed by the total/pass/fail counts. Intended for baseline generation
and comparison.

Test file paths are relative to -test262Dir or cwd and always use
forward slash seperators so baselines would be comparable across
OS platforms.
