### PR TITLE
Run tests over subfolders

### DIFF
--- a/lib/globber.js
+++ b/lib/globber.js
@@ -6,11 +6,12 @@ function globber(paths) {
   const files = new Rx.Subject();
   files.fileEvents = [];
 
-  const Glob = glob.Glob;
   let doneCount = 0;
 
   paths.forEach(function (path) {
-    const fileEvents = new Glob(path);
+    const fileEvents = new glob.Glob(path, {
+      nodir: true
+    });
 
     fileEvents.on('match', function (file) {
       files.onNext(file);
@@ -23,7 +24,7 @@ function globber(paths) {
     });
 
     files.fileEvents.push(fileEvents);
-  })
+  });
 
   return files;
 }


### PR DESCRIPTION
With this patch, test262-harness does not break passing folders or finding subfolders.

passing different paths will now work, where before only these forms were valid:

- `test/built-ins/Reflect/*.js`
- `test/built-ins/Reflect/**/*.js`

Now these other forms will be valid as well:

- `test/built-ins/Reflect/*`
- ~~`test/built-ins/Reflect/`~~
- ~~`test/built-ins/Reflect`~~

There's a last commit part where I still want to improve, rather than just setting a try catch. While I don't know how to solve it yet, I'll leave this open to request for some feedback.