### PR TITLE
Allow reporters to write to log files as well

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -41,7 +41,7 @@ const results = rawResults.map(function (test) {
   test.result = validator(test);
   return test;
 });
-const resultEmitter = resultsEmitter(results);
+const resultEmitter = resultsEmitter(results, argv);
 reporter(resultEmitter);
 
 function printVersion() {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,6 +6,8 @@ const yargv = yargs
   .describe('hostType', 'eshost host type (ch, d8, jsshell, chrome, firefox, etc.)')
   .describe('hostPath', 'path to eshost host binary')
   .describe('hostArgs', 'command-line arguments to pass to eshost host')
+  .describe('output', 'log output to file')
+  .describe('quiet', 'do not log results to stdout')
   .describe('test262Dir', 'test262 root directory')
   .describe('includesDir', 'directory where helper files are found')
   .describe('threads', 'number of threads to use')
@@ -18,6 +20,9 @@ const yargv = yargs
   .default('reporter', 'simple')
   .help('help')
   .alias('help', 'h')
+  .alias('output', 'o')
+  .alias('quiet', 'q')
+  .boolean('quiet')
   .example('test262-harness path/to/test.js')
 
 exports.argv = yargv.argv;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -4,21 +4,21 @@ function jsonReporter(results) {
   let started = false;
 
   results.on('start', function () {
-    console.log('[');
+    results.writeLine('[');
   });
 
-  results.on('end', function () { 
-    console.log(']');
+  results.on('end', function () {
+    results.writeLine(']');
   });
 
   results.on('test end', function (test) {
     if (started) {
-      process.stdout.write(',');
+      results.write(',');
     } else {
       started = true;
     }
 
-    console.log(JSON.stringify(test));
+    results.writeLine(JSON.stringify(test));
   });
 }
 

--- a/lib/reporters/simple.js
+++ b/lib/reporters/simple.js
@@ -10,28 +10,28 @@ function simpleReporter(results) {
 
     clearPassed();
     lastPassed = true;
-    process.stdout.write('PASS ' + test.file);
+    results.writeStdout('PASS ' + test.file);
   });
 
   results.on('fail', function (test) {
     failed++;
     clearPassed();
     lastPassed = false;
-    console.log('FAIL ' + test.file);
-    console.log('  ' + test.result.message);
-    console.log('');
+    results.writeLine('FAIL ' + test.file);
+    results.writeLine('  ' + test.result.message);
+    results.writeLine('');
   });
 
   results.on('end', function () {
     clearPassed();
 
-    console.log('Ran ' + (passed + failed) + ' tests')
-    console.log(passed + ' passed')
-    console.log(failed + ' failed')
+    results.writeLine('Ran ' + (passed + failed) + ' tests')
+    results.writeLine(passed + ' passed')
+    results.writeLine(failed + ' failed')
   });
 
   function clearPassed() {
-    if (lastPassed) {
+    if (lastPassed && !results.isQuiet()) {
       process.stdout.clearLine();
       process.stdout.cursorTo(0);
     }

--- a/lib/resultsEmitter.js
+++ b/lib/resultsEmitter.js
@@ -1,10 +1,58 @@
 'use strict';
 
 const EventEmitter = require('events');
+const fs = require('fs');
 
-function resultsEmitter(results) {
+function resultsEmitter(results, argv) {
   let started = false;
   const emitter = new EventEmitter();
+
+  if (argv.output) {
+    emitter.output = fs.createWriteStream(argv.output);
+  }
+
+  emitter.write = function() {
+    emitter.writeStdout.apply(this, arguments);
+    emitter.writeLog.apply(this, arguments);
+  };
+
+  emitter.writeLine = function() {
+    emitter.write.apply(this, arguments);
+    emitter.write("\n");
+  };
+
+  emitter.writeLog = function() {
+    if (!emitter.output) {
+      return;
+    }
+    for (let i = 0; i < arguments.length; i++) {
+      emitter.output.write(arguments[i]);
+    }
+  };
+
+  emitter.writeLogLine = function() {
+    emitter.writeLog.apply(this, arguments);
+    emitter.writeLog("\n");
+  };
+
+  emitter.writeStdout = function() {
+    if (argv.quiet) {
+      return;
+    }
+    for (let i = 0; i < arguments.length; i++) {
+      process.stdout.write(arguments[i]);
+    }
+  };
+
+  emitter.writeStdoutLine = function() {
+    emitter.writeStdout.apply(this, arguments);
+    emitter.writeStdout("\n");
+  };
+
+  emitter.isQuiet = function() {
+      return argv.quiet;
+  };
+
   results.forEach(
     function (test) {
       if (!started) {
@@ -24,7 +72,7 @@ function resultsEmitter(results) {
       console.error("ERROR", err);
     },
     function () {
-      emitter.emit('end')
+      emitter.emit('end');
     });
 
   return emitter;


### PR DESCRIPTION
This pr should allow to store log results to a file, which would be helpful for windows (as there isn't an easy and reliable stdout pipe syntax) or for programs that simply prefer to process files instead of stdout streams.

I'm not really sure how the api should look like and I might need to test this patch a bit more (I might have missed a few edgy cases).

For now I have put the output api inside the resultsEmitter and didn't touch anything related with the readline api.
