### PR TITLE
Don't attempt to clear non-TTY output in simple results reporter

### DIFF
--- a/lib/reporters/simple.js
+++ b/lib/reporters/simple.js
@@ -32,8 +32,12 @@ function simpleReporter(results) {
 
   function clearPassed() {
     if (lastPassed) {
-      process.stdout.clearLine();
-      process.stdout.cursorTo(0);
+      if (process.stdout.isTTY) {
+        process.stdout.clearLine();
+        process.stdout.cursorTo(0);
+      } else {
+        process.stdout.write('\n');
+      }
     }
   }
 }


### PR DESCRIPTION
Redirecting output currently causes exceptions because `process.stdout.clearLine()` only works for TTYs. This patch inserts a newline instead.