### PR TITLE
Fixes for printVersion. See detail

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -22,6 +22,12 @@ let test262Dir = argv.test262Dir;
 // where to load includes from (usually a subdirectory of test262dir)
 let includesDir = argv.includesDir;
 
+// print version of test262-harness
+if (argv.version) {
+  printVersion();
+  process.exit(0);
+}
+
 // initialize reporter by attempting to load lib/reporters/${reporter}
 // defaults to 'simple'
 let reporter;
@@ -83,8 +89,8 @@ const resultEmitter = resultsEmitter(results);
 reporter(resultEmitter);
 
 function printVersion() {
-    var p = require(path.resolve(__dirname, "..", "package.json"));
-    console.log("test262-harness v" + p.version);
+  var p = require(Path.resolve(__dirname, "..", "package.json"));
+  console.log(`v${p.version}`);
 }
 
 function pathToTestFile(path) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -9,6 +9,8 @@ const yargv = yargs
   .describe('includesDir', 'directory where helper files are found')
   .describe('threads', 'number of threads to use')
   .describe('prelude', 'content to include above each test')
+  .describe('version', 'print version of test262-harness')
+  .alias('version', 'v')
   .nargs('prelude', 1)
   .nargs('threads', 1)
   .default('threads', 1)


### PR DESCRIPTION
- "path" => "Path" in printVersion
- adds "--version" to cli args
- call printVersion() and exit when --version

```
$ test262-harness -v
v2.4.0
$ test262-harness --version
v2.4.0
```
Signed-off-by: Rick Waldron <waldron.rick@gmail.com>