### PR TITLE
Show --help when CLI is called with no arguments

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -8,7 +8,8 @@ const compile = require('test262-compiler');
 const fs = require('fs');
 const Path = require('path');
 const globber = require('../lib/globber.js');
-const argv = require('../lib/cli.js').argv;
+const cli = require('../lib/cli.js');
+const argv = cli.argv;
 const validator = require('../lib/validator.js');
 const Rx = require('rx');
 const util = require('util');
@@ -63,6 +64,12 @@ if (argv.hostType) {
 }
 
 argv.timeout = argv.timeout || DEFAULT_TEST_TIMEOUT;
+
+// Show help if no arguments provided
+if (!argv._.length) {
+  cli.showHelp();
+  process.exit(1);
+}
 
 // Test Pipeline
 const pool = agentPool(Number(argv.threads), hostType, argv.hostArgs, hostPath, { timeout: argv.timeout });

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -24,3 +24,6 @@ const yargv = yargs
   .example('test262-harness path/to/test.js')
 
 exports.argv = yargv.argv;
+exports.showHelp = function() {
+  yargv.showHelp();
+}


### PR DESCRIPTION
Currently there is an issue (documented in #69) where a cryptic error is displayed when the CLI is called with no arguments. While the use of `--help` is documented in the README, it would be more user-friendly for the CLI to default to showing the usage message if no argument is provided at invocation.

Fixes #69; there may be a more elegant way to solve this problem, but this felt like the most straightforward.