### PR TITLE
Support transpilation with Babel

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -85,6 +85,11 @@ if (argv.hostType) {
 }
 
 argv.timeout = argv.timeout || DEFAULT_TEST_TIMEOUT;
+let transpiler;
+if (argv.babelPresets) {
+  let babel = require('babel-core');
+  transpiler = code => babel.transform(code, { presets: argv.babelPresets.split(",") }).code;
+}
 
 // Show help if no arguments provided
 if (!argv._.length) {
@@ -94,7 +99,8 @@ if (!argv._.length) {
 }
 
 // Test Pipeline
-const pool = agentPool(Number(argv.threads), hostType, argv.hostArgs, hostPath, { timeout: argv.timeout });
+const pool = agentPool(Number(argv.threads), hostType, argv.hostArgs, hostPath,
+                       { timeout: argv.timeout, transpiler });
 const paths = globber(argv._);
 if (!includesDir && !test262Dir) {
   test262Dir = test262Finder(paths.fileEvents[0]);

--- a/lib/agentPool.js
+++ b/lib/agentPool.js
@@ -10,7 +10,8 @@ module.exports = function makePool(agentCount, hostType, hostArguments, hostPath
     eshost.createAgent(hostType, {
       hostArguments,
       hostPath,
-      shortName: '$262'
+      shortName: '$262',
+      transpiler: options.transpiler,
     })
     .then(agent => {
       agents.push(agent);

--- a/lib/agentPool.js
+++ b/lib/agentPool.js
@@ -11,7 +11,7 @@ module.exports = function makePool(agentCount, hostType, hostArguments, hostPath
       hostArguments,
       hostPath,
       shortName: '$262',
-      transpiler: options.transpiler,
+      transform: options.transpiler,
     })
     .then(agent => {
       agents.push(agent);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -11,6 +11,7 @@ const yargv = yargs
   .describe('prelude', 'content to include above each test')
   .describe('version', 'print version of test262-harness')
   .alias('version', 'v')
+  .describe('babelPresets', 'Babel presets used to transpile code')
   .nargs('prelude', 1)
   .nargs('threads', 1)
   .default('threads', 1)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "eshost": "^3.4.0",
+    "eshost": "^3.5.0",
     "glob": "^7.0.5",
     "rx": "^4.1.0",
     "test262-compiler": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   ],
   "devDependencies": {
     "rimraf": "^2.5.3",
-    "tape": "^3.6.1"
+    "tape": "^3.6.1",
+    "babel-core": "^6.24.1",
+    "babel-preset-stage-3": "^6.24.1"
   }
 }

--- a/test/babel-collateral/spread-sngl-obj-ident.js
+++ b/test/babel-collateral/spread-sngl-obj-ident.js
@@ -1,0 +1,18 @@
+/*---
+description: Test requiring transpilation
+expected:
+  pass: true
+---*/
+
+let o = {c: 3, d: 4};
+
+let callCount = 0;
+
+(function(obj) {
+  assert.sameValue(obj.c, 3);
+  assert.sameValue(obj.d, 4);
+  assert.sameValue(Object.keys(obj).length, 2);
+  callCount += 1;
+}({...o}));
+
+assert.sameValue(callCount, 1);

--- a/test/test.js
+++ b/test/test.js
@@ -9,7 +9,8 @@ Promise.all([
   run(['--reporter-keys', 'attrs,result', 'test/collateral/bothStrict.js']),
   run(['--reporter-keys', 'rawResult,attrs,result', 'test/collateral/bothStrict.js']),
   run(['--reporter-keys', 'attrs,rawResult,result', 'test/collateral/bothStrict.js']),
-  run(['--reporter-keys', 'attrs,result,rawResult', 'test/collateral/bothStrict.js'])
+  run(['--reporter-keys', 'attrs,result,rawResult', 'test/collateral/bothStrict.js']),
+  run(['--babelPresets', 'stage-3', '--reporter-keys', 'attrs,result,rawResult', 'test/babel-collateral/spread-sngl-obj-ident.js'])
 ])
 .then(validate)
 .catch(reportRunError);
@@ -52,7 +53,7 @@ function run(extraArgs) {
 function validate(records) {
   const [
     normal, prelude, withoutRawResult, withRawResult1, withRawResult2,
-    withRawResult3
+    withRawResult3, babelResult
   ] = records;
   validateResultRecords(normal);
   validateResultRecords(prelude, { prelude: true });
@@ -60,6 +61,7 @@ function validate(records) {
   validateResultRecords(withRawResult1);
   validateResultRecords(withRawResult2);
   validateResultRecords(withRawResult3);
+  validateResultRecords(babelResult);
 }
 
 function validateResultRecords(records, options = { prelude: false }) {


### PR DESCRIPTION
Allows Babel to be used as a transpiler, before passing to the underlying host, with the command-line flag `--babelPreset stage-2`, for example.

Depends on this patch https://github.com/bterlson/eshost/pull/19 , so eshost would have to rev a semver-minor and this patch would have to depend on that, before landing.