### PR TITLE
Correct interpretation of `negative` metadata

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -45,15 +45,14 @@ module.exports = function validate(test) {
       if (!result.error) {
         return {
           pass: false,
-          message: `Expected test to throw error matching ${test.attrs.negative}, but did not throw error`
+          message: `Expected test to throw error of type ${test.attrs.negative.type}, but did not throw error`
         };
-      } else if (result.error.name.match(new RegExp(test.attrs.negative)) ||
-          result.error.message === test.attrs.negative) {
+      } else if (result.error.name == test.attrs.negative.type) {
         return { pass: true };
       } else {
         return {
           pass: false,
-          message: `Expected test to throw error matching ${test.attrs.negative}, got ${result.error.name}: ${result.error.message}`
+          message: `Expected test to throw error of type ${test.attrs.negative.type}, got ${result.error.name}: ${result.error.message}`
         };
       }
     }


### PR DESCRIPTION
In October of 2016, the frontmatter format of Test262 tests was updated
to include more information about expected errors [1]. Prior to that
change, the `negative` attribute was defined as a regular expression
that matched the expected error's `name` attribute. Following that
change, the `negative` attribute is defined as a dictionary containing
`phase` and `type` attributes. The `type` attribute is a string value
describing the expected error's `name` attribute.

Update the validation logic to interpret the meta data according to this
new format.

[1] https://github.com/tc39/test262/pull/778

(It looks like things have been working because `/[object Object]/` matches the "o" present in all Error names.)