### PR TITLE
Update test/collateral/*.js negative frontmatter format

### DIFF
--- a/test/collateral/asyncNegative.js
+++ b/test/collateral/asyncNegative.js
@@ -1,10 +1,12 @@
 /*---
 description: Async test
-negative: RangeError
+negative:
+  phase: runtime
+  type: RangeError
 expected:
   pass: true
 ---*/
 
 setTimeout(function() {
-    $DONE(new RangeError());
+  $DONE(new RangeError());
 }, 1000);

--- a/test/collateral/bothStrict.js
+++ b/test/collateral/bothStrict.js
@@ -1,6 +1,8 @@
 /*---
 description: Should test in both modes
-negative: ReferenceError
+negative:
+  phase: runtime
+  type: ReferenceError
 expected:
   pass: true
 ---*/

--- a/test/collateral/strict.js
+++ b/test/collateral/strict.js
@@ -1,7 +1,9 @@
 /*---
 description: Should not test in sloppy mode
 flags: [onlyStrict]
-negative: ReferenceError
+negative:
+  phase: runtime
+  type: ReferenceError
 expected:
   pass: true
 ---*/


### PR DESCRIPTION
Presently...

```
1..48
# tests 48
# pass  41
# fail  7
```

After this patch is applied...

```
1..48
# tests 48
# pass  48

# ok
```

Signed-off-by: Rick Waldron <waldron.rick@gmail.com>