### PR TITLE
Mark failures with "(strict)" or "(non-strict)"

### DIFF
--- a/lib/reporters/simple.js
+++ b/lib/reporters/simple.js
@@ -10,24 +10,24 @@ function simpleReporter(results) {
 
     clearPassed();
     lastPassed = true;
-    process.stdout.write('PASS ' + test.file);
+    process.stdout.write(`PASS ${test.file}`);
   });
 
   results.on('fail', function (test) {
     failed++;
     clearPassed();
     lastPassed = false;
-    console.log('FAIL ' + test.file);
-    console.log('  ' + test.result.message);
+    console.log(`FAIL ${test.file}${test.strictMode ? ' (strict)' : ' (non-strict)'}`);
+    console.log(`  ${test.result.message}`);
     console.log('');
   });
 
   results.on('end', function () {
     clearPassed();
 
-    console.log('Ran ' + (passed + failed) + ' tests')
-    console.log(passed + ' passed')
-    console.log(failed + ' failed')
+    console.log(`Ran ${(passed + failed)} tests`);
+    console.log(`${passed} passed`);
+    console.log(`${failed} failed`);
   });
 
   function clearPassed() {


### PR DESCRIPTION
Before:
```
$ test262-harness --hostType jsc --hostPath `which jsc` test/language/function-code/each-param-has-own-*.js
FAIL test/language/function-code/each-param-has-own-non-shared-eval-scope.js
  Expected a ReferenceError to be thrown but no exception was thrown at all

FAIL test/language/function-code/each-param-has-own-scope.js
  Expected a ReferenceError to be thrown but no exception was thrown at all

Ran 4 tests
2 passed
2 failed
```


After:

```
$ test262-harness --hostType jsc --hostPath `which jsc` test/language/function-code/each-param-has-own-*.js
FAIL test/language/function-code/each-param-has-own-non-shared-eval-scope.js (non-strict)
  Expected a ReferenceError to be thrown but no exception was thrown at all

FAIL test/language/function-code/each-param-has-own-scope.js (non-strict)
  Expected a ReferenceError to be thrown but no exception was thrown at all

Ran 4 tests
2 passed
2 failed
```