### PR TITLE
Correct saved path format for --saveCompiledTests help message

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -30,7 +30,7 @@ const yargv = yargs
   .describe('timeout', 'test timeout (in ms, default 10000)')
   .nargs('timeout', 1)
   .describe('acceptVersion', 'override for supported Test262 version')
-  .describe('saveCompiledTests', 'Write the compiled version of path/to/test.js as path/to/test.<hostType>.js so that it can be easily re-run under that host')
+  .describe('saveCompiledTests', 'Write the compiled version of path/to/test.js as path/to/test.js.<hostType>.<pass|fail> so that it can be easily re-run under that host')
   .boolean('saveOnlyFailed')
   .describe('saveOnlyFailed', 'Only save the compiled version of the test if it failed, to help easily repro failed tests (implies --saveCompiledTests)')
   .example('test262-harness path/to/test.js')


### PR DESCRIPTION
By the way, the reason I made this change (at least for .js to not come at the end) was so that *.js globs wouldn't match the compiled tests when re-running a test262-harness command.