### PR TITLE
Fix package.json "license" key per `npm install` warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "yargs": "^4.7.1"
   },
   "author": "Brian Terlson",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "files": [
     "index.js",
     "bin",


### PR DESCRIPTION
```
>npm install
npm WARN test262-harness@3.6.0 license should be a valid SPDX license expression
```

GitHub detected the license from LICENSE.txt as BSD-3-Clause