### PR TITLE
Optimize tests

### DIFF
--- a/test/accept-version.js
+++ b/test/accept-version.js
@@ -1,3 +1,4 @@
+'use strict';
 const tap = require('tap');
 
 const run = require('./util/run');

--- a/test/accept-version.js
+++ b/test/accept-version.js
@@ -1,0 +1,39 @@
+const tap = require('tap');
+
+const run = require('./util/run');
+
+tap.test('unsupported version without `acceptVersion`', (test) => {
+  run(['test/collateral-unsupported-version/test/**/*.js'])
+    .then(() => {
+      test.fail('Expected command to fail, but it succeeded.');
+    }, () => {})
+    .then(test.done);
+});
+
+tap.test('supported version with matching `acceptVersion`', (test) => {
+  run(['test/collateral-supported-version/test/**/*.js',  '--acceptVersion', '3.0.0'])
+    .catch(test.fail)
+    .then(test.done);
+});
+
+tap.test('supported version with non-matching `acceptVersion`', (test) => {
+  run(['test/collateral-supported-version/test/**/*.js',  '--acceptVersion', '99.0.0'])
+    .then(() => {
+      test.fail('Expected command to fail, but it succeeded.');
+    }, () => {})
+    .then(test.done);
+});
+
+tap.test('unsupported version with matching `acceptVersion`', (test) => {
+  run(['test/collateral-unsupported-version/test/**/*.js',  '--acceptVersion', '99.0.0'])
+    .catch(test.fail)
+    .then(test.done);
+});
+
+tap.test('unsupported version with non-matching `acceptVersion`', (test) => {
+  run(['test/collateral-unsupported-version/test/**/*.js',  '--acceptVersion', '98.0.0'])
+    .then(() => {
+      test.fail('Expected command to fail, but it succeeded.');
+    }, () => {})
+    .then(test.done);
+});

--- a/test/save-compiled-tests.js
+++ b/test/save-compiled-tests.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 

--- a/test/save-compiled-tests.js
+++ b/test/save-compiled-tests.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+const tap = require('tap');
+const glob = require('glob');
+
+const run = require('./util/run');
+
+tap.test('saving compiled tests', assert => {
+  const sourcepattern = path.join(process.cwd(), 'test/collateral-save/test/*.js');
+  const resultpattern = path.join(process.cwd(), 'test/collateral-save/test/*.{fail,pass}');
+
+  const sources = glob.sync(sourcepattern);
+
+  tap.test('save all compiled tests with `--saveCompiledTests`', assert => {
+    run([sourcepattern, '--saveCompiledTests'])
+      .catch(assert.fail)
+      .then(() => {
+        const results = glob.sync(resultpattern);
+        assert.equal(results.length, sources.length, 'Expecting an equal number of result files to source files.');
+
+        return Promise.all(
+          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+        );
+      }).then(assert.done);
+  });
+
+  tap.test('save failed compiled tests with `--saveCompiledTests --saveOnlyFailed`', assert => {
+
+    run([sourcepattern, '--saveCompiledTests', '--saveOnlyFailed'])
+      .catch(assert.fail)
+      .then(() => {
+        const results = glob.sync(resultpattern);
+        assert.equal(results.length, 3, 'Expecting 3 result files.');
+
+        return Promise.all(
+          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+        );
+      }).catch(error => console.log(error)).then(assert.done);
+  });
+
+  tap.test('save failed compiled tests with `--saveOnlyFailed` (implies `--saveCompiledTests`)', assert => {
+
+    run([sourcepattern, '--saveOnlyFailed'])
+      .catch(assert.fail)
+      .then(() => {
+        const results = glob.sync(resultpattern);
+        assert.equal(results.length, 3, 'Expecting 3 result files.');
+
+        return Promise.all(
+          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+        );
+      }).catch(error => console.log(error)).then(assert.done);
+  });
+
+  assert.done();
+});

--- a/test/save-compiled-tests.js
+++ b/test/save-compiled-tests.js
@@ -6,52 +6,48 @@ const glob = require('glob');
 
 const run = require('./util/run');
 
-tap.test('saving compiled tests', assert => {
-  const sourcepattern = path.join(process.cwd(), 'test/collateral-save/test/*.js');
-  const resultpattern = path.join(process.cwd(), 'test/collateral-save/test/*.{fail,pass}');
+const sourcepattern = path.join(process.cwd(), 'test/collateral-save/test/*.js');
+const resultpattern = path.join(process.cwd(), 'test/collateral-save/test/*.{fail,pass}');
 
-  const sources = glob.sync(sourcepattern);
+const sources = glob.sync(sourcepattern);
 
-  tap.test('save all compiled tests with `--saveCompiledTests`', assert => {
-    run([sourcepattern, '--saveCompiledTests'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, sources.length, 'Expecting an equal number of result files to source files.');
+tap.test('save all compiled tests with `--saveCompiledTests`', assert => {
+  run([sourcepattern, '--saveCompiledTests'])
+    .catch(assert.fail)
+    .then(() => {
+      const results = glob.sync(resultpattern);
+      assert.equal(results.length, sources.length, 'Expecting an equal number of result files to source files.');
 
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).then(assert.done);
-  });
+      return Promise.all(
+        results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+      );
+    }).then(assert.done);
+});
 
-  tap.test('save failed compiled tests with `--saveCompiledTests --saveOnlyFailed`', assert => {
+tap.test('save failed compiled tests with `--saveCompiledTests --saveOnlyFailed`', assert => {
 
-    run([sourcepattern, '--saveCompiledTests', '--saveOnlyFailed'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, 3, 'Expecting 3 result files.');
+  run([sourcepattern, '--saveCompiledTests', '--saveOnlyFailed'])
+    .catch(assert.fail)
+    .then(() => {
+      const results = glob.sync(resultpattern);
+      assert.equal(results.length, 3, 'Expecting 3 result files.');
 
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).catch(error => console.log(error)).then(assert.done);
-  });
+      return Promise.all(
+        results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+      );
+    }).catch(error => console.log(error)).then(assert.done);
+});
 
-  tap.test('save failed compiled tests with `--saveOnlyFailed` (implies `--saveCompiledTests`)', assert => {
+tap.test('save failed compiled tests with `--saveOnlyFailed` (implies `--saveCompiledTests`)', assert => {
 
-    run([sourcepattern, '--saveOnlyFailed'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, 3, 'Expecting 3 result files.');
+  run([sourcepattern, '--saveOnlyFailed'])
+    .catch(assert.fail)
+    .then(() => {
+      const results = glob.sync(resultpattern);
+      assert.equal(results.length, 3, 'Expecting 3 result files.');
 
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).catch(error => console.log(error)).then(assert.done);
-  });
-
-  assert.done();
+      return Promise.all(
+        results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
+      );
+    }).catch(error => console.log(error)).then(assert.done);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,11 +1,8 @@
-const cp = require('child_process');
-const fs = require('fs');
-const path = require('path');
 
 const tap = require('tap');
-const glob = require('glob');
 
 const parseFile = require('test262-parser').parseFile;
+const run = require('./util/run');
 
 Promise.all([
   run(['test/collateral/test/**/*.js']),
@@ -23,35 +20,6 @@ function reportRunError(error) {
   console.error('Error running tests');
   console.error(error.stack);
   process.exit(1);
-}
-
-function run(extraArgs) {
-  return new Promise((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    let args = [
-        '--hostType', 'node',
-        '--hostPath', process.execPath,
-        '-r', 'json',
-        '--includesDir', './test/test-includes',
-      ].concat(extraArgs);
-
-    const child = cp.fork('bin/run.js', args, { silent: true });
-
-    child.stdout.on('data', (data) => { stdout += data });
-    child.stderr.on('data', (data) => { stderr += data });
-    child.on('exit', () => {
-      if (stderr) {
-        return reject(new Error(`Got stderr: ${stderr.toString()}`));
-      }
-
-      try {
-        resolve(JSON.parse(stdout));
-      } catch(e) {
-        reject(e);
-      }
-    });
-  });
 }
 
 function validate(records) {
@@ -115,89 +83,3 @@ function validateResultRecords(records, options = { prelude: false }) {
     });
   });
 }
-
-tap.test('unsupported version without `acceptVersion`', (test) => {
-  run(['test/collateral-unsupported-version/test/**/*.js'])
-    .then(() => {
-      test.fail('Expected command to fail, but it succeeded.');
-    }, () => {})
-    .then(test.done);
-});
-
-tap.test('supported version with matching `acceptVersion`', (test) => {
-  run(['test/collateral-supported-version/test/**/*.js',  '--acceptVersion', '3.0.0'])
-    .catch(test.fail)
-    .then(test.done);
-});
-
-tap.test('supported version with non-matching `acceptVersion`', (test) => {
-  run(['test/collateral-supported-version/test/**/*.js',  '--acceptVersion', '99.0.0'])
-    .then(() => {
-      test.fail('Expected command to fail, but it succeeded.');
-    }, () => {})
-    .then(test.done);
-});
-
-tap.test('unsupported version with matching `acceptVersion`', (test) => {
-  run(['test/collateral-unsupported-version/test/**/*.js',  '--acceptVersion', '99.0.0'])
-    .catch(test.fail)
-    .then(test.done);
-});
-
-tap.test('unsupported version with non-matching `acceptVersion`', (test) => {
-  run(['test/collateral-unsupported-version/test/**/*.js',  '--acceptVersion', '98.0.0'])
-    .then(() => {
-      test.fail('Expected command to fail, but it succeeded.');
-    }, () => {})
-    .then(test.done);
-});
-
-tap.test('saving compiled tests', assert => {
-  const sourcepattern = path.join(process.cwd(), 'test/collateral-save/test/*.js');
-  const resultpattern = path.join(process.cwd(), 'test/collateral-save/test/*.{fail,pass}');
-
-  const sources = glob.sync(sourcepattern);
-
-  tap.test('save all compiled tests with `--saveCompiledTests`', assert => {
-    run([sourcepattern, '--saveCompiledTests'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, sources.length, 'Expecting an equal number of result files to source files.');
-
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).then(assert.done);
-  });
-
-  tap.test('save failed compiled tests with `--saveCompiledTests --saveOnlyFailed`', assert => {
-
-    run([sourcepattern, '--saveCompiledTests', '--saveOnlyFailed'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, 3, 'Expecting 3 result files.');
-
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).catch(error => console.log(error)).then(assert.done);
-  });
-
-  tap.test('save failed compiled tests with `--saveOnlyFailed` (implies `--saveCompiledTests`)', assert => {
-
-    run([sourcepattern, '--saveOnlyFailed'])
-      .catch(assert.fail)
-      .then(() => {
-        const results = glob.sync(resultpattern);
-        assert.equal(results.length, 3, 'Expecting 3 result files.');
-
-        return Promise.all(
-          results.map(result => new Promise(resolve => fs.unlink(result, () => resolve())))
-        );
-      }).catch(error => console.log(error)).then(assert.done);
-  });
-
-  assert.done();
-});

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+'use strict';
 
 const tap = require('tap');
 

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -1,3 +1,4 @@
+'use strict';
 const cp = require('child_process');
 
 module.exports = function run(extraArgs) {

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -1,0 +1,30 @@
+const cp = require('child_process');
+
+module.exports = function run(extraArgs) {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    let args = [
+        '--hostType', 'node',
+        '--hostPath', process.execPath,
+        '-r', 'json',
+        '--includesDir', './test/test-includes',
+      ].concat(extraArgs);
+
+    const child = cp.fork('bin/run.js', args, { silent: true });
+
+    child.stdout.on('data', (data) => { stdout += data });
+    child.stderr.on('data', (data) => { stderr += data });
+    child.on('exit', () => {
+      if (stderr) {
+        return reject(new Error(`Got stderr: ${stderr.toString()}`));
+      }
+
+      try {
+        resolve(JSON.parse(stdout));
+      } catch(e) {
+        reject(e);
+      }
+    });
+  });
+};

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -8,6 +8,7 @@ module.exports = function run(extraArgs) {
         '--hostType', 'node',
         '--hostPath', process.execPath,
         '-r', 'json',
+        '--timeout', '2000',
         '--includesDir', './test/test-includes',
       ].concat(extraArgs);
 


### PR DESCRIPTION
Spread tests across more files and decrease the time required to detect timeout
while testing. This is intended to improve the contributor workflow and to
avoid the timeout failures that have been reported intermittently by the
project's continuous integration system.
