### PR TITLE
Add relative path for each test file

### DIFF
--- a/lib/test-stream.js
+++ b/lib/test-stream.js
@@ -43,7 +43,7 @@ module.exports = function(test262Dir, includesDir, acceptVersion, globPatterns) 
 
     // Preserve the relative file path from Test262, ignore the initial test/
     // folder.
-    test.path = path.relative('test', test.file);
+    test.relative = path.relative('test', test.file);
 
     // The file paths emitted by test262-stream are relative to the provided
     // Test262 directory. To ensure backwards compatability, they must be

--- a/lib/test-stream.js
+++ b/lib/test-stream.js
@@ -41,6 +41,10 @@ module.exports = function(test262Dir, includesDir, acceptVersion, globPatterns) 
       return;
     }
 
+    // Preserve the relative file path from Test262, ignore the initial test/
+    // folder.
+    test.path = path.relative('test', test.file);
+
     // The file paths emitted by test262-stream are relative to the provided
     // Test262 directory. To ensure backwards compatability, they must be
     // modified to be in terms of the current working directory.

--- a/test/file-matching.js
+++ b/test/file-matching.js
@@ -5,13 +5,13 @@ const path = require('path');
 const tap = require('tap');
 
 const sameMembers = (assert, actual, expected) => {
-  const expectedSet = new Set(expected.map((expectedMember) => {
+  const expectedSet = expected.map((expectedMember) => {
     return expectedMember.split('/').join(path.sep);
-  }));
+  });
   assert.equal(actual.length, expected.length);
 
   for (let actualMember of actual) {
-    assert.assert(expectedSet.has(actualMember), actualMember);
+    assert.assert(expectedSet.includes(actualMember), actualMember);
   }
 };
 
@@ -47,11 +47,16 @@ function run(extraArgs) {
 tap.test('file matching: file name', assert => {
   run(['test/collateral-nested/test/evens/2.js'])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
@@ -61,12 +66,18 @@ tap.test('file matching: file names', assert => {
       'test/collateral-nested/test/mixed/2.js'
     ])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral-nested/test/mixed/2.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'mixed/2.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
@@ -76,37 +87,56 @@ tap.test('file matching: file names (outside of Test262 directory)', assert => {
       'test/collateral/test/strict.js'
     ])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral/test/strict.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        '../../collateral/test/strict.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
 tap.test('file matching: glob: any directory (shallow)', assert => {
   run(['test/collateral-nested/test/*/2.js'])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral-nested/test/mixed/2.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'mixed/2.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
 tap.test('file matching: glob: any directory (deep)', assert => {
   run(['test/collateral-nested/test/**/2.js'])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral-nested/test/mixed/2.js',
         'test/collateral-nested/test/mixed/deep/2.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'mixed/2.js',
+        'mixed/deep/2.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
@@ -114,8 +144,9 @@ tap.test('file matching: glob: any directory (deep)', assert => {
 tap.test('file matching: glob: partial filename', assert => {
   run(['test/collateral-nested/test/**/2*.js'])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral-nested/test/evens/deep/26.js',
         'test/collateral-nested/test/mixed/23.js',
@@ -124,20 +155,38 @@ tap.test('file matching: glob: partial filename', assert => {
         'test/collateral-nested/test/mixed/deep/2.js',
         'test/collateral-nested/test/odds/23.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'evens/deep/26.js',
+        'mixed/23.js',
+        'mixed/2.js',
+        'mixed/deep/26.js',
+        'mixed/deep/2.js',
+        'odds/23.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });
 
 tap.test('file matching: glob: partial directory name', assert => {
   run(['test/collateral-nested/test/*s/*.js'])
     .then((results) => {
-      const actual = results.map((result) => result.file);
-      const expected = [
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
         'test/collateral-nested/test/evens/2.js',
         'test/collateral-nested/test/evens/42.js',
         'test/collateral-nested/test/odds/23.js',
-        'test/collateral-nested/test/odds/3.js',
+        'test/collateral-nested/test/odds/3.js'
       ];
-      sameMembers(assert, actual, expected);
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'evens/42.js',
+        'odds/23.js',
+        'odds/3.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
     }).then(assert.done, assert.fail);
 });


### PR DESCRIPTION
I take advantage of this small feature in the json reporter.

I'm up to bikeshed over names of this property. My first option was `relPath` but I wonder this is problematic in case insensitive scenarios or anything. An alternative is `rel_path`. While I don't find a perfect solution, just `path` might do the trick just fine.

I can also benefit a lot by removing the leading `test/` from each file path.



