### PR TITLE
Capture nested keys for the json reporter

### DIFF
--- a/lib/pick.js
+++ b/lib/pick.js
@@ -2,7 +2,30 @@
 
 module.exports = function(obj, keys) {
   return keys.reduce((accum, key) => {
-    accum[key] = obj[key];
+    if (!key.includes('.')) {
+      // Regular keys, just add them
+      accum[key] = obj[key];
+      return accum;
+    }
+
+    // Complex keys, let's split them out
+    const [parent, child] = key.split('.');
+
+    // No need to add if it's already adding the whole parent property.
+    if (keys.includes(parent)) {
+      return accum;
+    }
+
+    // Fail-safe bail from undefined property
+    if (!obj[parent]) {
+      return accum;
+    }
+
+    if (!accum[parent]) {
+      accum[parent] = {};
+    }
+
+    accum[parent][child] = obj[parent][child];
     return accum;
   }, {});
 };

--- a/test/reporter-keys.js
+++ b/test/reporter-keys.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const tap = require('tap');
+const _run = require('./util/run');
+
+function run(...args) {
+  return _run([
+    ...args,
+    '--includesDir',
+    './test/test-includes',
+    './test/collateral-nested/test/**/*.js'
+  ]).then(({records}) => records);
+}
+
+tap.test('all keys', assert => {
+  run()
+    .then(results => {
+      const expectedKeys = [
+        'file', 'result', 'contents', 'attrs', 'copyright', 'scenario',
+        'rawResult', 'compiled'
+      ];
+      for (const result of results) {
+        for (const key of expectedKeys) {
+          assert.assert(result.hasOwnProperty(key), `${result} has '${key}' property`);
+        }
+      }
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('selected single key', assert => {
+  run('--reporter-keys=file')
+    .then(results => {
+      for (const result of results) {
+        assert.assert(result.hasOwnProperty('file'), `${result} has 'file' property`);
+        assert.equal(Object.keys(result).length, 1);
+      }
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('selected multiple keys', assert => {
+  run('--reporter-keys=attrs,scenario')
+    .then(results => {
+      for (const result of results) {
+        assert.assert(result.hasOwnProperty('attrs'), `${result} has 'attrs' property`);
+        assert.assert(result.hasOwnProperty('scenario'), `${result} has 'scenario' property`);
+        assert.equal(Object.keys(result).length, 2);
+      }
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('selected single complex key', assert => {
+  run('--reporter-keys=attrs.description')
+    .then(results => {
+      for (const result of results) {
+        assert.assert(result.hasOwnProperty('attrs'), `${result} has 'attrs' property`);
+        assert.equal(Object.keys(result).length, 1);
+
+        assert.assert(
+          result.attrs.hasOwnProperty('description'),
+          `${result}.attrs has 'description' property`
+        );
+        assert.equal(Object.keys(result.attrs).length, 1);
+      }
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('selected multiple complex keys', assert => {
+  run('--reporter-keys=attrs.description,attrs.includes,rawResult.error')
+    .then(results => {
+      for (const result of results) {
+        assert.assert(result.hasOwnProperty('attrs'), `${result} has 'attrs' property`);
+        assert.assert(result.hasOwnProperty('rawResult'), `${result} has 'rawResult' property`);
+        assert.equal(Object.keys(result).length, 2, 'selects only two parent keys');
+
+        assert.assert(
+          result.attrs.hasOwnProperty('description'),
+          `${result}.attrs has 'description' property`
+        );
+
+        assert.assert(
+          result.attrs.hasOwnProperty('includes'),
+          `${result}.attrs has 'includes' property`
+        );
+
+        assert.equal(
+          Object.keys(result.attrs).length, 2,
+          'selects two parent keys from the attrs property'
+        );
+
+        assert.assert(
+          result.rawResult.hasOwnProperty('error'),
+          `${result}.rawResult has 'error' property`
+        );
+
+        assert.equal(
+          Object.keys(result.rawResult).length, 1,
+          'selects only one property from rawResult'
+        );
+      }
+    }).then(assert.done, assert.fail);
+});


### PR DESCRIPTION
```
test262-harness --reporter=json --reporter-keys=attrs.esid --hostType=x --hostPath=`which x` -- test/built-ins/Array/*
```

See the `attrs.esid` in the reporter-keys option.