### PR TITLE
Do not emit the same test more than once

### DIFF
--- a/lib/test-stream.js
+++ b/lib/test-stream.js
@@ -25,8 +25,32 @@ function patternsToDirectories(patterns) {
       return true;
     });
 
-    return parts.join(path.sep);
-  }).filter((name) => name !== '');
+    return parts.join(path.sep)
+  })
+  .filter((name) => name !== '')
+  // Remove elements that would cause the same files to be visited more than
+  // once:
+  //
+  // - duplicate elements (e.g. `a/b` if `a/b` is present elsewhere)
+  // - elements which describe subdirectories of of some other element (e.g.
+  //   `c/d/e` if `c/d` is also present)
+  .filter((name, index, all) => {
+    return all.every((other, otherIndex) => {
+      // Allow only the first occurrence of repeated values (de-duplicate)
+      if (name === other) {
+          return index <= otherIndex;
+      }
+
+      // When one value contains another, only allow the shorter of the two
+      const min = Math.min(name.length, other.length);
+      if (name.substr(0, min) === other.substr(0, min)) {
+        return name.length < other.length;
+      }
+
+      // All other values are unique and should be allowed
+      return true;
+    });
+  });
 }
 
 module.exports = function(test262Dir, includesDir, acceptVersion, globPatterns) {

--- a/test/file-matching.js
+++ b/test/file-matching.js
@@ -81,6 +81,69 @@ tap.test('file matching: file names', assert => {
     }).then(assert.done, assert.fail);
 });
 
+tap.test('file matching: file names (siblings)', assert => {
+  run([
+      'test/collateral-nested/test/evens/2.js',
+      'test/collateral-nested/test/evens/42.js'
+    ])
+    .then((results) => {
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
+        'test/collateral-nested/test/evens/2.js',
+        'test/collateral-nested/test/evens/42.js'
+      ];
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'evens/42.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('file matching: file names (subdirectory first)', assert => {
+  run([
+      'test/collateral-nested/test/evens/deep/26.js',
+      'test/collateral-nested/test/evens/2.js'
+    ])
+    .then((results) => {
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
+        'test/collateral-nested/test/evens/deep/26.js',
+        'test/collateral-nested/test/evens/2.js'
+      ];
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/deep/26.js',
+        'evens/2.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
+    }).then(assert.done, assert.fail);
+});
+
+tap.test('file matching: file names (subdirectory second)', assert => {
+  run([
+      'test/collateral-nested/test/evens/2.js',
+      'test/collateral-nested/test/evens/deep/26.js'
+    ])
+    .then((results) => {
+      const files = results.map((result) => result.file);
+      const relativePaths = results.map((result) => result.relative);
+      const expectedFiles = [
+        'test/collateral-nested/test/evens/2.js',
+        'test/collateral-nested/test/evens/deep/26.js'
+      ];
+      sameMembers(assert, files, expectedFiles);
+      const expectedRelPaths = [
+        'evens/2.js',
+        'evens/deep/26.js'
+      ];
+      sameMembers(assert, relativePaths, expectedRelPaths);
+    }).then(assert.done, assert.fail);
+});
+
 tap.test('file matching: file names (outside of Test262 directory)', assert => {
   run([
       'test/collateral-nested/test/evens/2.js',


### PR DESCRIPTION
The set of tests emitted by the `test262-stream` module is controlled by
a list of directories. This project supports file names and file
"globbing" patterns. To integrate the two interfaces, this project trims
file names and paths to their most specific directory names and passes
these names to `test262-stream`. The stream emits more tests than have
been requested, so the globbing patterns are used to filter the visited
tests.

Previously, for some input, the list of simplified directory names could
include duplicate elements, and some elements could describe
subdirectories of other elements. `test262-stream` responds to this
input by visiting files multiple times.

Ensure that only unique directories are provided to `test262-stream` so
that no test is emitted more than once.

This is intended to resolve gh-116