### PR TITLE
CLI: accepts path to "transformer"

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -127,6 +127,10 @@ if (argv.babelPresets) {
   transpiler = code => babel.transform(code, { presets }).code;
 }
 
+if (argv.transformer) {
+  transpiler = require(argv.transformer);
+}
+
 if (argv.features) {
   features = argv.features.split(',').map(feature => feature.trim());
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -16,6 +16,7 @@ const yargv = yargs
   .nargs('features', 1)
   .alias('features', 'f')
   .describe('babelPresets', 'Babel presets used to transpile code')
+  .describe('transformer', 'path to module which exports a code transformer function')
   .nargs('prelude', 1)
   .nargs('threads', 1)
   .default('threads', 1)


### PR DESCRIPTION
Example:

```
test262-harness --hostType=d8 --hostPath=$HOME/.jsvu/v8 --transformer=$TRANSFORMERS/spec.js test/language/destructuring/binding/initialization-requires-object-coercible-undefined.js
```

Where `$TRANSFORMERS/spec.js` is made by following these instructions: https://gist.github.com/rwaldron/da2f77605925f5092c0ccad3384f074a

That "transform" will converts this:

```js
function fn({}) {}

assert.throws(TypeError, function() {
  fn();
});
```

To something approximately like this:

```js
function _objectDestructuringEmpty(obj) { if (obj == null) throw new TypeError("Cannot destructure undefined"); }

function fn(_ref) {
  _objectDestructuringEmpty(_ref);
}

assert.throws(TypeError, function () {
  fn();
});
```