### PR TITLE
Defer version enforcement checks to test262-stream

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -3,7 +3,6 @@
 // Copyright (C) 2014, Microsoft Corporation. All rights reserved.
 // This code is governed by the BSD License found in the LICENSE file.
 const DEFAULT_TEST_TIMEOUT = 10000;
-const ACCEPTED_TEST262_VERSIONS = /^[1-4]\./
 
 const fs = require('fs');
 const path = require('path');
@@ -149,12 +148,8 @@ try {
   return;
 }
 
-if (acceptVersion ? acceptVersion !== test262Version :
-  !ACCEPTED_TEST262_VERSIONS.test(test262Version)) {
-
-  console.error(`Incompatible test262 version: ${test262Version}`);
-  process.exitCode = 1;
-  return;
+if (!acceptVersion) {
+  acceptVersion = test262Version;
 }
 
 const stream = new TestStream(test262Dir, includesDir, acceptVersion, argv._);

--- a/test/accept-version.js
+++ b/test/accept-version.js
@@ -6,9 +6,7 @@ const reporter = 'json';
 
 tap.test('unsupported version without `acceptVersion`', assert => {
   run(['test/collateral-unsupported-version/test/**/*.js'], {reporter})
-    .then(() => {
-      assert.fail('Expected command to fail, but it succeeded.');
-    }, () => {})
+    .catch(assert.fail)
     .then(assert.done);
 });
 
@@ -20,9 +18,7 @@ tap.test('supported version with matching `acceptVersion`', assert => {
 
 tap.test('supported version with non-matching `acceptVersion`', assert => {
   run(['test/collateral-supported-version/test/**/*.js',  '--acceptVersion', '99.0.0'], {reporter})
-    .then(() => {
-      assert.fail('Expected command to fail, but it succeeded.');
-    }, () => {})
+    .catch(assert.fail)
     .then(assert.done);
 });
 


### PR DESCRIPTION
Removes legacy version validation code. This is now handled by test262-stream and should not be double handled by test262-harness