### PR TITLE
feat: set exitCode to 1 when a test fails

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -178,6 +178,9 @@ const results = zip(pool, tests).pipe(
 );
 
 const emitter = new ResultsEmitter(results);
+emitter.on('fail', function () {
+  process.exitCode = 1;
+});
 reporter(emitter, reporterOpts);
 
 function printVersion() {


### PR DESCRIPTION
Right now `test262-harness` exit with `0` even though there're test failures. I believe it should be non-0 instead.