### PR TITLE
Revert "feat: set exitCode to 1 when a test fails"

### DIFF
--- a/bin/run.js
+++ b/bin/run.js
@@ -178,9 +178,6 @@ const results = zip(pool, tests).pipe(
 );
 
 const emitter = new ResultsEmitter(results);
-emitter.on('fail', function () {
-  process.exitCode = 1;
-});
 reporter(emitter, reporterOpts);
 
 function printVersion() {


### PR DESCRIPTION
This reverts commit a3e2a051ad1a63db8475ecb2b13295b92cd92c54.

Test failures are not an exceptional event. By reporting them as though
they are exceptional, test262-harness forces consumers to ignore the
status code. This makes it difficult to detect true operational errors,
e.g. when the interpreter under test crashes, since they are
indistinguishable from test failures.

Consumers who wish to react to test failures should do so by parsing the
tool's output.