### PR TITLE
Re-implement recent change in exit status to require opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ test262-harness --hostType=X --hostPath=`which X` test/**/*.js
 | `--acceptVersion` | Execute tests from a version of Test262 that differs from the versions supported by this utility. This may cause the utility to report invalid test results. | No | Inferred from `test262Dir/package.json` |
 | `--saveCompiledTests` | Write the compiled version of `path/to/test.js` as `path/to/test.js.<hostType>.<default\|strict>.<pass\|fail>` so that it can be easily re-run under that host. Run `test262-harness --help` for examples. | No | n/a 
 | `--saveOnlyFailed` | Only save the compiled version of the test if it failed, to help easily repro failed tests (implies `--saveCompiledTests`). | No | n/a 
+| `--errorForFailures` | Return a non-zero exit code if one or more tests fail. | No | n/a
 
 
 ### Preprocessor

--- a/bin/run.js
+++ b/bin/run.js
@@ -178,9 +178,6 @@ const results = zip(pool, tests).pipe(
 );
 
 const emitter = new ResultsEmitter(results);
-emitter.on('fail', function () {
-  process.exitCode = 1;
-});
 reporter(emitter, reporterOpts);
 
 function printVersion() {

--- a/bin/run.js
+++ b/bin/run.js
@@ -178,6 +178,13 @@ const results = zip(pool, tests).pipe(
 );
 
 const emitter = new ResultsEmitter(results);
+
+if (argv.errorForFailures) {
+  emitter.on('fail', function () {
+    process.exitCode = 1;
+  });
+}
+
 reporter(emitter, reporterOpts);
 
 function printVersion() {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -37,6 +37,7 @@ const yargv = yargs
   .describe('saveCompiledTests', 'Write the compiled version of path/to/test.js as path/to/test.js.<hostType>.<default|strict>.<pass|fail> so that it can be easily re-run under that host')
   .boolean('saveOnlyFailed')
   .describe('saveOnlyFailed', 'Only save the compiled version of the test if it failed, to help easily repro failed tests (implies --saveCompiledTests)')
+  .describe('errorForFailures', 'Return a non-zero exit code if one or more tests fail')
   .example('test262-harness path/to/test.js')
   .example('test262-harness --hostType ch --hostPath path/to/host path/to/test262/test/folder/**/*.js')
   .example('test262-harness --hostType ch --hostPath path/to/host --saveCompiledTests path/to/test262/test/folder/**/*.js')

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,7 @@ const tests = [
       '--includesDir', './test/test-includes',
       './test/collateral/test/**/*.js',
     ],
+    { exitCode: 1 },
   ],
   [
     [
@@ -47,7 +48,7 @@ const tests = [
       '--includesDir', './test-includes',
       'collateral/test/**/*.js',
     ],
-    { cwd: 'test' },
+    { cwd: 'test', exitCode: 1 },
   ],
   [
     [
@@ -115,7 +116,8 @@ const tests = [
       '--preprocessor', './test/preprocessor/autofail.js',
       '--reporter-keys', 'attrs,result,rawResult',
       './test/collateral-preprocessor/test/autofail.js',
-    ]
+    ],
+    { exitCode: 1 },
   ],
 ].reduce((accum, a) => {
   let b = a.slice();
@@ -143,12 +145,17 @@ function reportRunError(error) {
   process.exit(1);
 }
 
-function validate({ args, records, options = { prelude: false } }) {
+function validate({ args, records, exitCode, options }) {
+  tap.test(`exit code with args \`${args.join(' ')}\``, assert => {
+    const expectedExitCode = options && options.exitCode || 0;
+    assert.equal(exitCode, expectedExitCode, 'exited with correct code');
+    assert.end();
+  });
 
   if (options.reporter === 'json') {
     records.forEach(record => {
-
-      const description = options.prelude ?
+      const prelude = options && options.prelude;
+      const description = prelude ?
         `${record.attrs.description} with prelude` :
         record.attrs.description;
 
@@ -179,7 +186,7 @@ function validate({ args, records, options = { prelude: false } }) {
                       'Test fails with appropriate message');
         }
 
-        if (options.prelude) {
+        if (prelude) {
           assert.ok(record.rawResult.stdout.includes('prelude a!'),
                     'Has prelude-a content');
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,6 @@ const tests = [
       '--includesDir', './test/test-includes',
       './test/collateral/test/**/*.js',
     ],
-    { exitCode: 1 },
   ],
   [
     [
@@ -48,7 +47,7 @@ const tests = [
       '--includesDir', './test-includes',
       'collateral/test/**/*.js',
     ],
-    { cwd: 'test', exitCode: 1 },
+    { cwd: 'test' },
   ],
   [
     [
@@ -117,7 +116,6 @@ const tests = [
       '--reporter-keys', 'attrs,result,rawResult',
       './test/collateral-preprocessor/test/autofail.js',
     ],
-    { exitCode: 1 },
   ],
 ].reduce((accum, a) => {
   let b = a.slice();

--- a/test/test.js
+++ b/test/test.js
@@ -13,6 +13,12 @@ const tests = [
   ],
   [
     [
+      'test/**/*.js', '--error-for-failures',
+    ],
+    { cwd: 'test/collateral-with-harness/test262' },
+  ],
+  [
+    [
       '--test262Dir', './test/collateral-with-harness/test262',
       './test/collateral-with-harness/test262/test/**/*.js',
     ],
@@ -116,6 +122,16 @@ const tests = [
       '--reporter-keys', 'attrs,result,rawResult',
       './test/collateral-preprocessor/test/autofail.js',
     ],
+  ],
+  [
+    [
+      '--includesDir', './test/test-includes',
+      '--preprocessor', './test/preprocessor/autofail.js',
+      '--reporter-keys', 'attrs,result,rawResult',
+      './test/collateral-preprocessor/test/autofail.js',
+      '--errorForFailures',
+    ],
+    { exitCode: 1 },
   ],
 ].reduce((accum, a) => {
   let b = a.slice();

--- a/test/util/run.js
+++ b/test/util/run.js
@@ -32,6 +32,7 @@ module.exports = function run(extraArgs, options) {
         resolve({
           args,
           options,
+          exitCode: child.exitCode,
           records,
         });
       } catch(e) {


### PR DESCRIPTION
This supersedes gh-140 by restoring the exit code behavior prior to gh-137 and exposing that new functionality via an opt-in flag (similar to traditional command-line utilities like `grep`). It also adds tests since the CLI's exit code was not previously validated.

The name `--errorOnFailure` feels slightly more familiar than `--errorForFailures`. Some users may interpret the former to mean "report error upon first failure," or in other words "bail out as soon as any test fails." That's not the intent here, and I hope `--errorForFailures` makes that more clear.

/cc @longlho